### PR TITLE
deployment fix

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: ECS Fargate Service for Node.js Express API with ALB health checks (commit SHA tagging)
+Description: ECS Fargate Service for Node.js Express API with Logging
 
 Parameters:
   VpcId:
@@ -16,9 +16,6 @@ Parameters:
     Type: String
   AwsRegion:
     Type: String
-  ImageTag:
-    Type: String
-    Description: "Unique Docker image tag (commit SHA)"
 
 Resources:
   Cluster:
@@ -38,6 +35,13 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/ecs-express-api
+      RetentionInDays: 7
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -51,15 +55,16 @@ Resources:
       ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
       ContainerDefinitions:
         - Name: ecs-express-container
-          Image: !Sub "${EcrRegistry}/${EcrRepository}:${ImageTag}"
+          Image: !Sub "${EcrRegistry}/${EcrRepository}:latest"
           Essential: true
           PortMappings:
             - ContainerPort: 3000
-          Environment:
-            - Name: PORT
-              Value: "3000"
-            - Name: APP_NAME
-              Value: "ecs-express-api"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AwsRegion
+              awslogs-stream-prefix: ecs
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -80,15 +85,11 @@ Resources:
       Port: 3000
       Protocol: HTTP
       TargetType: ip
-      HealthCheckProtocol: HTTP
-      HealthCheckPort: "3000"
       HealthCheckPath: /health
-      Matcher:
-        HttpCode: 200
-      HealthyThresholdCount: 2
-      UnhealthyThresholdCount: 3
-      HealthCheckIntervalSeconds: 15
+      HealthCheckIntervalSeconds: 30
       HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
 
   Listener:
     Type: AWS::ElasticLoadBalancingV2::Listener


### PR DESCRIPTION
This pull request updates the CloudFormation template for the ECS Fargate Service to add centralized logging support and simplify deployment parameters. The changes focus on enabling AWS CloudWatch logging for the Node.js Express API, removing commit SHA-based image tagging, and streamlining health check configuration.

**Logging enhancements:**

* Added a new `LogGroup` resource for CloudWatch Logs and updated the ECS task execution role to include `CloudWatchLogsFullAccess` permissions.
* Configured the ECS container to use the `awslogs` log driver, specifying the log group, region, and stream prefix for centralized logging.

**Deployment and configuration simplification:**

* Removed the `ImageTag` parameter and switched the container image reference to always use the `latest` tag, reducing deployment complexity. [[1]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL19-L21) [[2]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL54-R67)
* Removed unnecessary environment variables from the container definition to further simplify configuration.

**Health check adjustments:**

* Updated the target group health check settings to increase the interval to 30 seconds and set healthy/unhealthy threshold counts to 2, while removing explicit protocol, port, and matcher settings for clarity.