### PR TITLE
Dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy ECS Express API
+name: Deploy to ECS
 
 on:
   push:
@@ -8,73 +8,65 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Log in to Amazon ECR
-        run: |
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} \
-          | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build Docker Image
+      - name: Build, Tag, and Push image
         run: |
-          IMAGE_TAG=${{ github.sha }}
-          docker build -t ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG .
+          IMAGE_TAG=${GITHUB_SHA::8}
+          IMAGE_URI=${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG
+          docker build -t $IMAGE_URI .
+          docker push $IMAGE_URI
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_ENV
 
-      - name: Tag Docker Image
+      - name: Deploy CloudFormation Stack
         run: |
-          IMAGE_TAG=${{ github.sha }}
-          docker tag ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG
-
-      - name: Push to ECR
-        run: |
-          IMAGE_TAG=${{ github.sha }}
-          docker push ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG
-
-      - name: Install AWS SAM CLI
-        uses: aws-actions/setup-sam@v2
-
-      - name: Deploy with SAM
-        run: |
-          IMAGE_TAG=${{ github.sha }}
-          sam deploy \
+          aws cloudformation deploy \
             --template-file template.yaml \
-            --stack-name ecs-express-api-stack \
+            --stack-name ecs-express-stack \
             --capabilities CAPABILITY_IAM \
-            --region ${{ secrets.AWS_REGION }} \
-            --no-fail-on-empty-changeset \
             --parameter-overrides \
               VpcId=${{ secrets.VPC_ID }} \
               Subnet1=${{ secrets.SUBNET_1 }} \
               Subnet2=${{ secrets.SUBNET_2 }} \
               SecurityGroup=${{ secrets.SECURITY_GROUP }} \
-              EcrRegistry=${{ secrets.ECR_REGISTRY }} \
-              EcrRepository=${{ secrets.ECR_REPOSITORY }} \
-              AwsRegion=${{ secrets.AWS_REGION }} \
-              ImageTag=$IMAGE_TAG
+              ImageUri=${IMAGE_URI} \
+            --no-fail-on-empty-changeset
 
-      - name: Fetch ALB DNS from CloudFormation
-        id: alb-dns
+      - name: Wait for stack to finish
+        run: |
+          echo "Waiting for stack update to complete..."
+          aws cloudformation wait stack-update-complete \
+            --stack-name ecs-express-stack || \
+          aws cloudformation wait stack-create-complete \
+            --stack-name ecs-express-stack
+
+      - name: Print ALB DNS and Logs
         run: |
           DNS=$(aws cloudformation describe-stacks \
-            --stack-name ecs-express-api-stack \
-            --region ${{ secrets.AWS_REGION }} \
-            --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNS'].OutputValue" \
+            --stack-name ecs-express-stack \
+            --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNSName'].OutputValue" \
             --output text)
-          echo "alb_dns=$DNS" >> $GITHUB_OUTPUT
-          echo "Application Load Balancer DNS: $DNS"
 
-      - name: Show API Endpoint
-        run: |
-          echo "==========================================="
-          echo " Your ECS Express API is available at:"
-          echo "   http://${{ steps.alb-dns.outputs.alb_dns }}/health"
-          echo "==========================================="
+          LOG_GROUP=$(aws cloudformation describe-stacks \
+            --stack-name ecs-express-stack \
+            --query "Stacks[0].Outputs[?OutputKey=='CloudWatchLogGroup'].OutputValue" \
+            --output text)
+
+          echo "====================================="
+          echo " ✅ Your API is available at: http://$DNS"
+          echo " 📜 View logs in CloudWatch group: $LOG_GROUP"
+          echo "====================================="

--- a/template.yaml
+++ b/template.yaml
@@ -29,7 +29,7 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
-      ExecutionRoleArn: arn:aws:iam::YOUR_ACCOUNT_ID:role/ecsTaskExecutionRole
+      ExecutionRoleArn: arn:aws:iam::864981759262:role/ecsTaskExecutionRole
       ContainerDefinitions:
         - Name: express-container
           Image: !Ref ImageUri

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,3 @@
-AWSTemplateFormatVersion: '2010-09-09'
-Description: ECS Fargate Service for Node.js Express API with Logging
-
 Parameters:
   VpcId:
     Type: String
@@ -10,86 +7,69 @@ Parameters:
     Type: String
   SecurityGroup:
     Type: String
-  EcrRegistry:
-    Type: String
-  EcrRepository:
-    Type: String
-  AwsRegion:
+  ImageUri:
     Type: String
 
 Resources:
   Cluster:
     Type: AWS::ECS::Cluster
-    Properties:
-      ClusterName: ecs-express-cluster
-
-  TaskExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-            Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
-        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
 
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: /ecs/ecs-express-api
-      RetentionInDays: 7
+      LogGroupName: /ecs/express-api
+      RetentionInDays: 7  # keep logs for 7 days
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: ecs-express-task
+      Family: express-task
       Cpu: '256'
       Memory: '512'
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
-      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      ExecutionRoleArn: arn:aws:iam::YOUR_ACCOUNT_ID:role/ecsTaskExecutionRole
       ContainerDefinitions:
-        - Name: ecs-express-container
-          Image: !Sub "${EcrRegistry}/${EcrRepository}:latest"
-          Essential: true
+        - Name: express-container
+          Image: !Ref ImageUri
           PortMappings:
             - ContainerPort: 3000
-          LogConfiguration:
+          Environment:
+            - Name: PORT
+              Value: "3000"
+          LogConfiguration:                # ✅ CloudWatch logs enabled
             LogDriver: awslogs
             Options:
               awslogs-group: !Ref LogGroup
-              awslogs-region: !Ref AwsRegion
+              awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: ecs
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: ecs-express-lb
+      Name: express-alb
+      Scheme: internet-facing
       Subnets:
         - !Ref Subnet1
         - !Ref Subnet2
       SecurityGroups:
         - !Ref SecurityGroup
-      Scheme: internet-facing
-      Type: application
 
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      VpcId: !Ref VpcId
+      Name: express-tg
       Port: 3000
       Protocol: HTTP
       TargetType: ip
+      VpcId: !Ref VpcId
       HealthCheckPath: /health
       HealthCheckIntervalSeconds: 30
-      HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      UnhealthyThresholdCount: 2
+      UnhealthyThresholdCount: 5
+      Matcher:
+        HttpCode: 200
 
   Listener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -103,26 +83,31 @@ Resources:
 
   Service:
     Type: AWS::ECS::Service
-    DependsOn: Listener
     Properties:
       Cluster: !Ref Cluster
-      LaunchType: FARGATE
       DesiredCount: 1
-      TaskDefinition: !Ref TaskDefinition
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups:
-            - !Ref SecurityGroup
           Subnets:
             - !Ref Subnet1
             - !Ref Subnet2
+          SecurityGroups:
+            - !Ref SecurityGroup
+      TaskDefinition: !Ref TaskDefinition
       LoadBalancers:
-        - ContainerName: ecs-express-container
+        - TargetGroupArn: !Ref TargetGroup
+          ContainerName: express-container
           ContainerPort: 3000
-          TargetGroupArn: !Ref TargetGroup
 
 Outputs:
-  LoadBalancerDNS:
-    Description: Public endpoint for the API
+  LoadBalancerDNSName:
+    Description: Public URL of the load balancer
     Value: !GetAtt LoadBalancer.DNSName
+  CloudWatchLogGroup:
+    Description: Log group for ECS container logs
+    Value: !Ref LogGroup


### PR DESCRIPTION
This pull request updates the deployment workflow and CloudFormation template to streamline and modernize the ECS deployment process for the Express API. The changes focus on simplifying the GitHub Actions workflow, switching from AWS SAM to direct CloudFormation deployment, and cleaning up resource definitions and parameters in `template.yaml`.

**Workflow improvements and deployment process:**

* The GitHub Actions workflow (`.github/workflows/deploy.yml`) now uses direct CloudFormation deployment instead of AWS SAM, consolidating Docker build, tag, and push steps, and providing clearer status output and log access after deployment.
* The workflow uses `${GITHUB_SHA::8}` for image tagging and passes the full image URI to CloudFormation, improving traceability and reducing risk of tag collisions.

**CloudFormation template simplification and modernization:**

* The `template.yaml` parameters have been cleaned up: removed unused ECR and region parameters, and replaced them with a single `ImageUri` parameter for more flexible image referencing.
* Resource names and properties have been standardized (e.g., changing cluster, service, and container names to use "express" instead of "ecs-express"), and hardcoded the execution role ARN for clarity (note: this will need to be replaced with your actual account ID).
* The ECS service definition now includes deployment configuration options for better rollout control, and the resource dependencies and ordering have been improved.

**Outputs and logging enhancements:**

* CloudFormation outputs now include both the load balancer DNS name and the CloudWatch log group, making it easier to locate the API endpoint and container logs after deployment.
* The workflow prints both the public API endpoint and the log group name at the end of deployment for quick access.

**Minor improvements:**

* Various naming conventions and comments have been updated for clarity and consistency across both the workflow and template files. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R1) [[2]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL1-L3)

Let me know if you have questions about any of these changes!