### PR TITLE
updated ci cd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,16 +25,13 @@ jobs:
           | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
 
       - name: Build Docker Image
-        run: |
-          IMAGE_TAG=${{ github.sha }}
-          docker build -t ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG .
-          docker build -t ${{ secrets.ECR_REPOSITORY }}:latest .
+        run: docker build -t ${{ secrets.ECR_REPOSITORY }} .
 
       - name: Tag Docker Image
         run: |
           IMAGE_TAG=${{ github.sha }}
           docker tag ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG
-          docker tag ${{ secrets.ECR_REPOSITORY }}:latest ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
+          docker tag ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
 
       - name: Push to ECR
         run: |
@@ -47,7 +44,6 @@ jobs:
 
       - name: Deploy with SAM
         run: |
-          IMAGE_TAG=${{ github.sha }}
           sam deploy \
             --template-file template.yaml \
             --stack-name ecs-express-api-stack \
@@ -58,31 +54,16 @@ jobs:
               VpcId=${{ secrets.VPC_ID }} \
               Subnet1=${{ secrets.SUBNET_1 }} \
               Subnet2=${{ secrets.SUBNET_2 }} \
-              SecurityGroup=${{ secrets.SECURITY_GROUP }} \
               EcrRegistry=${{ secrets.ECR_REGISTRY }} \
               EcrRepository=${{ secrets.ECR_REPOSITORY }} \
-              AwsRegion=${{ secrets.AWS_REGION }} \
-              ImageTag=$IMAGE_TAG
+              AwsRegion=${{ secrets.AWS_REGION }}
 
-      - name: Verify API Health
+      - name: Fetch ALB DNS from CloudFormation
         run: |
-          echo "Fetching ALB DNS..."
-          ENDPOINT=$(aws cloudformation describe-stacks \
+          echo "Fetching ALB DNS name..."
+          ALB_DNS=$(aws cloudformation describe-stacks \
             --stack-name ecs-express-api-stack \
             --query "Stacks[0].Outputs[?OutputKey=='LoadBalancerDNS'].OutputValue" \
             --output text)
-          echo "Testing API at: http://$ENDPOINT/health"
-
-          for i in {1..10}; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://$ENDPOINT/health || true)
-            if [ "$STATUS" -eq 200 ]; then
-              echo "✅ API is healthy!"
-              exit 0
-            else
-              echo "⏳ Attempt $i: not healthy yet (status: $STATUS)"
-              sleep 10
-            fi
-          done
-
-          echo "❌ API did not become healthy in time."
-          exit 1
+          echo "✅ ALB DNS: http://$ALB_DNS"
+          echo "::set-output name=alb_dns::$ALB_DNS"

--- a/template.yaml
+++ b/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: ECS Fargate Service for Node.js Express API
+Description: ECS Fargate Service for Node.js Express API with ALB + Security Groups
 
 Parameters:
   VpcId:
@@ -8,17 +8,12 @@ Parameters:
     Type: String
   Subnet2:
     Type: String
-  SecurityGroup:
-    Type: String
   EcrRegistry:
     Type: String
   EcrRepository:
     Type: String
   AwsRegion:
     Type: String
-  ImageTag:
-    Type: String
-    Description: "Docker image tag (commit SHA)"
 
 Resources:
   Cluster:
@@ -39,6 +34,12 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
 
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/ecs-express-api
+      RetentionInDays: 7
+
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -51,7 +52,7 @@ Resources:
       ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
       ContainerDefinitions:
         - Name: ecs-express-container
-          Image: !Sub "${EcrRegistry}/${EcrRepository}:${ImageTag}"
+          Image: !Sub "${EcrRegistry}/${EcrRepository}:latest"
           Essential: true
           PortMappings:
             - ContainerPort: 3000
@@ -62,11 +63,27 @@ Resources:
               awslogs-region: !Ref AwsRegion
               awslogs-stream-prefix: ecs
 
-  LogGroup:
-    Type: AWS::Logs::LogGroup
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
     Properties:
-      LogGroupName: /ecs/ecs-express-api
-      RetentionInDays: 7
+      GroupDescription: Allow HTTP traffic from internet to ALB
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+
+  EcsSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow ECS tasks traffic from ALB
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3000
+          ToPort: 3000
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -76,7 +93,7 @@ Resources:
         - !Ref Subnet1
         - !Ref Subnet2
       SecurityGroups:
-        - !Ref SecurityGroup
+        - !Ref AlbSecurityGroup
       Scheme: internet-facing
       Type: application
 
@@ -88,10 +105,8 @@ Resources:
       Protocol: HTTP
       TargetType: ip
       HealthCheckPath: /health
-      HealthCheckIntervalSeconds: 30
-      HealthCheckTimeoutSeconds: 5
-      HealthyThresholdCount: 2
-      UnhealthyThresholdCount: 2
+      Matcher:
+        HttpCode: 200
 
   Listener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -111,12 +126,11 @@ Resources:
       LaunchType: FARGATE
       DesiredCount: 1
       TaskDefinition: !Ref TaskDefinition
-      HealthCheckGracePeriodSeconds: 30
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
           SecurityGroups:
-            - !Ref SecurityGroup
+            - !Ref EcsSecurityGroup
           Subnets:
             - !Ref Subnet1
             - !Ref Subnet2


### PR DESCRIPTION
This pull request updates the deployment workflow and CloudFormation template to simplify Docker image management and improve security group configuration for the ECS Fargate service. The changes remove the need to pass a dynamic image tag, standardize on the `latest` tag for deployments, and replace the single security group parameter with dedicated security groups for the ALB and ECS tasks. Additionally, the workflow now fetches the ALB DNS name for downstream use, and the template adds a log group resource.

**Deployment workflow simplification:**

* The build and tag steps in `.github/workflows/deploy.yml` now use only the `latest` tag for the Docker image, removing the use of commit SHA tags and related logic.
* The SAM deploy step no longer passes an image tag parameter, simplifying deployment commands and parameters. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L50) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L61-R69) [[3]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL11-L21) [[4]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL54-R55)

**Security group improvements:**

* The CloudFormation template replaces the single `SecurityGroup` parameter with two dedicated security groups: `AlbSecurityGroup` for the load balancer and `EcsSecurityGroup` for ECS tasks, with appropriate ingress rules for each. [[1]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL11-L21) [[2]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL65-R86) [[3]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL79-R96) [[4]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL114-R133)

**Resource enhancements:**

* A new CloudWatch log group resource (`LogGroup`) is added for ECS logs with a 7-day retention period.

**Health check and output updates:**

* The health check configuration for the target group is simplified to match only HTTP 200 responses, and the workflow now fetches and outputs the ALB DNS name instead of performing health checks directly. [[1]](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL91-R109) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L61-R69)

**Documentation:**

* The template description is updated to reflect the inclusion of ALB and security groups.