### PR TITLE
updated ci cd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,17 +25,18 @@ jobs:
           | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
 
       - name: Build Docker Image
-        run: docker build -t ${{ secrets.ECR_REPOSITORY }} .
-
-      - name: Tag Docker Image
         run: |
           IMAGE_TAG=${{ github.sha }}
+          # build with both SHA and latest tags
+          docker build -t ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG -t ${{ secrets.ECR_REPOSITORY }}:latest .
+
+      - name: Tag & Push to ECR
+        run: |
+          IMAGE_TAG=${{ github.sha }}
+          # tag images for ECR
           docker tag ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG
-          docker tag ${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
-
-      - name: Push to ECR
-        run: |
-          IMAGE_TAG=${{ github.sha }}
+          docker tag ${{ secrets.ECR_REPOSITORY }}:latest ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
+          # push both tags
           docker push ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:$IMAGE_TAG
           docker push ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
 
@@ -44,6 +45,7 @@ jobs:
 
       - name: Deploy with SAM
         run: |
+          IMAGE_TAG=${{ github.sha }}
           sam deploy \
             --template-file template.yaml \
             --stack-name ecs-express-api-stack \


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to streamline the Docker image build, tagging, and push steps, and to ensure proper tagging for both the commit SHA and `latest` versions. The changes also clarify the deployment step by explicitly setting the `IMAGE_TAG` variable.

**Docker build and tagging improvements:**

* Combined the build and tagging steps so the Docker image is built with both the SHA and `latest` tags in a single command, reducing redundancy and simplifying the workflow.

* Updated the push step to tag images for ECR and push both the SHA-specific and `latest` tags, ensuring both versions are available in the registry.

**Deployment step clarification:**

* Explicitly sets the `IMAGE_TAG` variable before running the SAM deployment command, improving clarity and consistency in the deployment process.